### PR TITLE
Fix mkl=2024.0 to avoid iJIT_NotifyEvent import error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - pip=21.2.*
 - ipykernel=6.0.*
 - pytorch::pytorch=1.9.* #- dgl=0.7.*
+- mkl=2024.0.*
 - nb_conda_kernels=2.3.*
 - seaborn=0.11.*
 - h5py


### PR DESCRIPTION
mkl 2024.1 removed `iJIT_NotifyEvent`. 
https://github.com/pytorch/pytorch/issues/123097

Up/downgrading by hand is a mess and everything breaks, but fixing mkl=2024.0 in environment.yml works.